### PR TITLE
`get_les()`: Update to include 118th Congress

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,4 +37,4 @@ Suggests:
 Config/testthat/edition: 3
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.2
+RoxygenNote: 7.3.3

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,20 @@
 # filibustr (development version)
 
+## Breaking changes
+* Updated the LES dataset in `get_les()` to include data from the 118th 
+  Congress (#30).
+  * Deprecated the `get_les(les_2)` argument. It is no longer applicable to the 
+  new format of the LES dataset, which includes both versions of LES in the 
+  same dataset.
+
+## Minor improvements and bug fixes
+* In `get_les()` and `get_hvw_data()`, preserve the `st_name` column for 
+  non-voting members of the House (i.e., members from D.C. and U.S. 
+  territories) (#32).
+* `get_les()` and `get_hvw_data()` see minor optimizations/speed improvements 
+  in their internal data cleaning processes.
+* Updated Roxygen version to 7.3.3.
+
 # filibustr 0.4.1 (2025-08-19)
 
 * Ensure web resources are online when running examples in function 

--- a/R/build_url.R
+++ b/R/build_url.R
@@ -10,7 +10,7 @@ build_url <- function(data_source, chamber = "all", congress = NULL, sheet_type 
                                   congress_code = congress_code),
     hvw = build_hvw_url(chamber_code = chamber_code),
     lhy = build_hvw_url(chamber_code = chamber_code),
-    les = build_les_url(les_2 = sheet_type, chamber_code = chamber_code),
+    les = build_les_url(chamber_code = chamber_code),
     "source not implemented"
   )
 
@@ -48,7 +48,7 @@ build_hvw_url <- function(chamber_code) {
   paste0(source, "/", file)
 }
 
-build_les_url <- function(chamber_code, les_2 = FALSE) {
+build_les_url <- function(chamber_code) {
   # no "all" option for LES
   if (!(chamber_code %in% c("H", "S"))) {
     cli::cli_abort(c(
@@ -58,11 +58,10 @@ build_les_url <- function(chamber_code, les_2 = FALSE) {
     call = rlang::caller_env(2))
   }
 
-  source <- "https://thelawmakers.org/wp-content/uploads/2023/04"
+  source <- "https://thelawmakers.org/wp-content/uploads/2025/03/CEL"
   chamber_name <- if (chamber_code == "H") "House" else "Senate"
-  sheet_type <- if (les_2) "117ReducedLES2" else "93to117ReducedClassic"
 
-  paste0(source, "/CEL", chamber_name, sheet_type, ".dta")
+  paste0(source, chamber_name, "93to118Reduced.dta")
 }
 
 match_chamber <- function(chamber) {

--- a/R/get_les.R
+++ b/R/get_les.R
@@ -71,7 +71,10 @@ get_les <- function(chamber, les_2 = FALSE, local_path = NULL) {
     df <- haven::read_dta(online_file)
   } else {
     # local reading
-    df <- read_local_file(path = local_path, show_col_types = FALSE)
+    df <- read_local_file(path = local_path,
+                          # ensure `lagles2` is read as a double, not a logical
+                          # (can error because it starts with many `NA`s)
+                          col_types = readr::cols(lagles2 = readr::col_double()))
   }
 
   df <- df |>
@@ -90,20 +93,18 @@ fix_les_coltypes <- function(df, local_path) {
     # using `any_of()` because of colname differences between S and HR sheets
     dplyr::mutate(dplyr::across(
       .cols = c("congress", "icpsr", "year", "elected",
-                "votepct", "seniority", "votepct_sq", "deleg_size",
-                "party_code", "born", "died",
+                "seniority", "deleg_size", "party_code", "born", "died",
+                "TotalInParty", "RankInParty1", "RankInParty2",
                 dplyr::any_of(c("cgnum", "sensq", "thomas_num", "cd")),
                 # bill progress columns (cbill, sslaw, etc.)
-                dplyr::matches(stringr::regex("^[:lower:]{1,3}bill[12]$")),
-                dplyr::matches(stringr::regex("^[:lower:]{1,3}aic[12]$")),
-                dplyr::matches(stringr::regex("^[:lower:]{1,3}abc[12]$")),
-                dplyr::matches(stringr::regex("^[:lower:]{1,3}pass[12]$")),
-                dplyr::matches(stringr::regex("^[:lower:]{1,3}law[12]$"))),
+                dplyr::matches(
+                  stringr::regex("^(c|s|ss|all)(bill|aic|abc|pass|law)[12]$")
+                )),
       .fns = as.integer)) |>
     dplyr::mutate(dplyr::across(
       .cols = c("dem", "majority", "female", "afam", "latino",
-                "chair", "subchr", "state_leg", "maj_leader",
-                "min_leader", "power", "freshman", dplyr::any_of("speaker")),
+                "chair", "subchr", "state_leg", "maj_leader", "min_leader",
+                "power", "freshman", dplyr::any_of("speaker")),
       .fns = as.logical))
 
   df <- df |> create_factor_columns(local_path = local_path)

--- a/R/get_les.R
+++ b/R/get_les.R
@@ -26,11 +26,12 @@
 #'    Senate data. Thus, the `year` for House members is one after that of
 #'    senators in the same Congress.
 #'
-#' @param les_2 Whether to use LES 2.0 (instead of Classic Legislative
-#'  Effectiveness Scores).  LES 2.0 credits lawmakers when language
-#'  from their sponsored bills is included in other legislators' bills
-#'  that become law. LES 2.0 is only available for the 117th Congress.
-#'  Classic LES is available for the 93rd through 117th Congresses.
+#' @param les_2 `r lifecycle::badge("deprecated")` This argument is now ignored
+#'  and will be removed in a future release. The 2025 LES dataset now includes
+#'  both LES Classic and LES 2.0 scores in the same dataset. LES 2.0 credits
+#'  lawmakers when language from their sponsored bills is included in other
+#'  legislators' bills that become law. LES 2.0 is only available starting in
+#'  the 117th Congress (2021-present).
 #'
 #' @param local_path (Optional) A file path for reading from a local file.
 #'  If no `local_path` is specified, will read data from the Center for
@@ -51,20 +52,13 @@
 #'
 #' @export
 #'
-#' @examplesIf interactive() && !is.null(curl::nslookup("thelawmakers.org", error = FALSE))
-#' # Classic LES data (93rd-117th Congresses)
-#' get_les("house", les_2 = FALSE)
-#' get_les("senate", les_2 = FALSE)
-#'
 #' @examplesIf !is.null(curl::nslookup("thelawmakers.org", error = FALSE))
-#' # LES 2.0 (117th Congress)
-#' get_les("house", les_2 = TRUE)
-#' get_les("senate", les_2 = TRUE)
-get_les <- function(chamber, les_2 = FALSE, local_path = NULL) {
+#' get_les("house")
+#' get_les("senate")
+get_les <- function(chamber, les_2 = lifecycle::deprecated(), local_path = NULL) {
   if (is.null(local_path)) {
     # online reading
-    # using `les_2` in place of a true `sheet_type`
-    url <- build_url(data_source = "les", chamber = chamber, sheet_type = les_2)
+    url <- build_url(data_source = "les", chamber = chamber)
     online_file <- get_online_data(url = url,
                                    source_name = "Center for Effective Lawmaking",
                                    return_format = "raw")

--- a/R/utils_data_cleaning.R
+++ b/R/utils_data_cleaning.R
@@ -5,15 +5,23 @@ create_factor_columns <- function(df, local_path) {
     df <- df |>
       # no need to specify levels if data is already coming from saved DTA file
       dplyr::mutate(dplyr::across(.cols = c(dplyr::any_of(c("state", "st_name")),
-                                            dplyr::matches("expectation[12]?$")),
+                                            dplyr::matches("^expectation[12]$")),
                                   .fns = haven::as_factor))
   } else {
     df <- df |>
-      dplyr::mutate(dplyr::across(.cols = dplyr::any_of(c("state", "st_name")),
-                                  .fns = ~ factor(.x, levels = datasets::state.abb))) |>
-      # LES vs. expectation (`expectation`/`expectation1`/`expectation2`)
-      dplyr::mutate(dplyr::across(.cols = dplyr::matches("expectation[12]?$"),
-                                  .fns = as.factor))
+      dplyr::mutate(
+        dplyr::across(.cols = dplyr::any_of("state"),
+                      # Senate data (`state`) just has members from the states
+                      .fns = ~ factor(.x, levels = datasets::state.abb)),
+        dplyr::across(.cols = dplyr::any_of("st_name"),
+                      .fns = ~ factor(.x, levels = c(
+                        # House data (`st_name`) includes non-voting members
+                        datasets::state.abb, "AS", "DC", "GU", "MP", "PR", "VI"
+                      ))),
+        # LES vs. expectation (`expectation1`/`expectation2`)
+        dplyr::across(.cols = dplyr::matches("^expectation[12]$"),
+                      .fns = as.factor)
+      )
   }
 
   df

--- a/R/utils_data_cleaning.R
+++ b/R/utils_data_cleaning.R
@@ -5,7 +5,7 @@ create_factor_columns <- function(df, local_path) {
     df <- df |>
       # no need to specify levels if data is already coming from saved DTA file
       dplyr::mutate(dplyr::across(.cols = c(dplyr::any_of(c("state", "st_name")),
-                                            dplyr::matches("^expectation[12]$")),
+                                            "expectation1", "expectation2"),
                                   .fns = haven::as_factor))
   } else {
     df <- df |>
@@ -18,8 +18,8 @@ create_factor_columns <- function(df, local_path) {
                         # House data (`st_name`) includes non-voting members
                         datasets::state.abb, "AS", "DC", "GU", "MP", "PR", "VI"
                       ))),
-        # LES vs. expectation (`expectation1`/`expectation2`)
-        dplyr::across(.cols = dplyr::matches("^expectation[12]$"),
+        # LES vs. expectation
+        dplyr::across(.cols = c("expectation1", "expectation2"),
                       .fns = as.factor)
       )
   }

--- a/R/utils_data_cleaning.R
+++ b/R/utils_data_cleaning.R
@@ -4,9 +4,9 @@ create_factor_columns <- function(df, local_path) {
   if (isTRUE(tools::file_ext(local_path) == "dta")) {
     df <- df |>
       # no need to specify levels if data is already coming from saved DTA file
-      dplyr::mutate(dplyr::across(.cols = c(dplyr::any_of(c("state", "st_name")),
-                                            dplyr::matches("^expectation[12]$")),
-                                  .fns = haven::as_factor))
+      dplyr::mutate(dplyr::across(
+        .cols = dplyr::any_of(c("state", "st_name", "expectation1", "expectation2")),
+        .fns = haven::as_factor))
   } else {
     df <- df |>
       dplyr::mutate(
@@ -18,8 +18,8 @@ create_factor_columns <- function(df, local_path) {
                         # House data (`st_name`) includes non-voting members
                         datasets::state.abb, "AS", "DC", "GU", "MP", "PR", "VI"
                       ))),
-        # LES vs. expectation (`expectation1`/`expectation2`)
-        dplyr::across(.cols = dplyr::matches("^expectation[12]$"),
+        # LES vs. expectation
+        dplyr::across(.cols = dplyr::any_of(c("expectation1", "expectation2")),
                       .fns = as.factor)
       )
   }

--- a/R/utils_data_cleaning.R
+++ b/R/utils_data_cleaning.R
@@ -5,7 +5,7 @@ create_factor_columns <- function(df, local_path) {
     df <- df |>
       # no need to specify levels if data is already coming from saved DTA file
       dplyr::mutate(dplyr::across(.cols = c(dplyr::any_of(c("state", "st_name")),
-                                            "expectation1", "expectation2"),
+                                            dplyr::matches("^expectation[12]$")),
                                   .fns = haven::as_factor))
   } else {
     df <- df |>
@@ -18,8 +18,8 @@ create_factor_columns <- function(df, local_path) {
                         # House data (`st_name`) includes non-voting members
                         datasets::state.abb, "AS", "DC", "GU", "MP", "PR", "VI"
                       ))),
-        # LES vs. expectation
-        dplyr::across(.cols = c("expectation1", "expectation2"),
+        # LES vs. expectation (`expectation1`/`expectation2`)
+        dplyr::across(.cols = dplyr::matches("^expectation[12]$"),
                       .fns = as.factor)
       )
   }

--- a/README.Rmd
+++ b/README.Rmd
@@ -77,9 +77,7 @@ There are non-trivial differences between the House and Senate datasets, so take
 Here is an example table returned by `get_les()`.
 
 ```{r LES example}
-library(filibustr)
-
-get_les(chamber = "senate", les_2 = FALSE)
+get_les(chamber = "senate")
 ```
 
 ### Harbridge-Yong, Volden, and Wiseman (2023)
@@ -91,8 +89,6 @@ The House and Senate data do not have the same number of variables, or the same 
 Here are the tables returned by `get_hvw_data()`:
 
 ```{r HVW example}
-library(filibustr)
-
 get_hvw_data("house")
 get_hvw_data("senate")
 ```

--- a/README.md
+++ b/README.md
@@ -104,29 +104,27 @@ so take care when joining House and Senate data.
 Here is an example table returned by `get_les()`.
 
 ``` r
-library(filibustr)
-
-get_les(chamber = "senate", les_2 = FALSE)
-#> # A tibble: 2,533 × 60
+get_les(chamber = "senate")
+#> # A tibble: 2,635 × 88
 #>    last     first state congress cgnum icpsr  year dem   majority elected female
 #>    <chr>    <chr> <fct>    <int> <int> <int> <int> <lgl> <lgl>      <int> <lgl> 
 #>  1 Abourezk James SD          93     1 13000  1972 TRUE  TRUE        1972 FALSE 
-#>  2 Aiken    Geor… VT          93     2    52  1972 FALSE FALSE       1940 FALSE 
-#>  3 Allen    James AL          93     3 12100  1972 TRUE  TRUE        1968 FALSE 
-#>  4 Baker    Howa… TN          93     4 11200  1972 FALSE FALSE       1966 FALSE 
-#>  5 Bartlett Dewey OK          93     5 14100  1972 FALSE FALSE       1972 FALSE 
-#>  6 Bayh     Birch IN          93     6 10800  1972 TRUE  TRUE        1962 FALSE 
-#>  7 Beall    J.    MD          93     7 12002  1972 FALSE FALSE       1970 FALSE 
-#>  8 Bellmon  Henry OK          93     8 12101  1972 FALSE FALSE       1968 FALSE 
-#>  9 Bennett  Wall… UT          93     9   645  1972 FALSE FALSE       1950 FALSE 
-#> 10 Bentsen  Lloyd TX          93    10   660  1972 TRUE  TRUE        1970 FALSE 
-#> # ℹ 2,523 more rows
-#> # ℹ 49 more variables: afam <lgl>, latino <lgl>, votepct <int>, chair <lgl>,
+#>  2 Allen    James AL          93     3 12100  1972 TRUE  TRUE        1968 FALSE 
+#>  3 Bayh     Birch IN          93     6 10800  1972 TRUE  TRUE        1962 FALSE 
+#>  4 Bentsen  Lloyd TX          93    10   660  1972 TRUE  TRUE        1970 FALSE 
+#>  5 Bible    Alan  NV          93    11   688  1972 TRUE  TRUE        1954 FALSE 
+#>  6 Biden    Jose… DE          93    12 14101  1972 TRUE  TRUE        1972 FALSE 
+#>  7 Burdick  Quen… ND          93    16  1252  1972 TRUE  TRUE        1960 FALSE 
+#>  8 Byrd     Robe… WV          93    18  1366  1972 TRUE  TRUE        1958 FALSE 
+#>  9 Cannon   Howa… NV          93    19  1482  1972 TRUE  TRUE        1958 FALSE 
+#> 10 Chiles   Lawt… FL          93    21 13101  1972 TRUE  TRUE        1970 FALSE 
+#> # ℹ 2,625 more rows
+#> # ℹ 77 more variables: afam <lgl>, latino <lgl>, votepct <dbl>, chair <lgl>,
 #> #   subchr <lgl>, seniority <int>, state_leg <lgl>, state_leg_prof <dbl>,
-#> #   maj_leader <lgl>, min_leader <lgl>, votepct_sq <int>, lagles <dbl>,
-#> #   power <lgl>, freshman <lgl>, sensq <int>, deleg_size <int>,
-#> #   party_code <int>, bioname <chr>, bioguide_id <chr>, born <int>, died <int>,
-#> #   dwnom1 <dbl>, dwnom2 <dbl>, meddist <dbl>, majdist <dbl>, cbill1 <int>, …
+#> #   maj_leader <lgl>, min_leader <lgl>, votepct_sq <dbl>, power <lgl>,
+#> #   freshman <lgl>, sensq <int>, deleg_size <int>, party_code <int>,
+#> #   bioname <chr>, bioguide_id <chr>, born <int>, died <int>, dwnom1 <dbl>,
+#> #   dwnom2 <dbl>, meddist <dbl>, majdist <dbl>, cbill1 <int>, caic1 <int>, …
 ```
 
 ### Harbridge-Yong, Volden, and Wiseman (2023)
@@ -141,8 +139,6 @@ the same variable names, so it is not trivial to join the two tables.
 Here are the tables returned by `get_hvw_data()`:
 
 ``` r
-library(filibustr)
-
 get_hvw_data("house")
 #> # A tibble: 9,825 × 109
 #>    thomas_num thomas_name     icpsr congress  year st_name    cd dem   elected

--- a/man/get_hvw_data.Rd
+++ b/man/get_hvw_data.Rd
@@ -49,10 +49,10 @@ These datasets have been dedicated to the public domain
 under \href{https://creativecommons.org/publicdomain/zero/1.0/}{CC0 1.0}.
 }
 \examples{
-\dontshow{if (!is.null(curl::nslookup("dataverse.harvard.edu", error = FALSE))) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (!is.null(curl::nslookup("dataverse.harvard.edu", error = FALSE))) withAutoprint(\{ # examplesIf}
 get_hvw_data("senate")
 \dontshow{\}) # examplesIf}
-\dontshow{if (interactive() && !is.null(curl::nslookup("dataverse.harvard.edu", error = FALSE))) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (interactive() && !is.null(curl::nslookup("dataverse.harvard.edu", error = FALSE))) withAutoprint(\{ # examplesIf}
 get_hvw_data("house")
 \dontshow{\}) # examplesIf}
 }

--- a/man/get_les.Rd
+++ b/man/get_les.Rd
@@ -61,12 +61,12 @@ United States Congress: The lawmakers}. Cambridge University Press.
 \doi{doi:10.1017/CBO9781139032360}
 }
 \examples{
-\dontshow{if (interactive() && !is.null(curl::nslookup("thelawmakers.org", error = FALSE))) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (interactive() && !is.null(curl::nslookup("thelawmakers.org", error = FALSE))) withAutoprint(\{ # examplesIf}
 # Classic LES data (93rd-117th Congresses)
 get_les("house", les_2 = FALSE)
 get_les("senate", les_2 = FALSE)
 \dontshow{\}) # examplesIf}
-\dontshow{if (!is.null(curl::nslookup("thelawmakers.org", error = FALSE))) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (!is.null(curl::nslookup("thelawmakers.org", error = FALSE))) withAutoprint(\{ # examplesIf}
 # LES 2.0 (117th Congress)
 get_les("house", les_2 = TRUE)
 get_les("senate", les_2 = TRUE)

--- a/man/get_les.Rd
+++ b/man/get_les.Rd
@@ -4,7 +4,7 @@
 \alias{get_les}
 \title{Get Legislative Effectiveness Scores data}
 \usage{
-get_les(chamber, les_2 = FALSE, local_path = NULL)
+get_les(chamber, les_2 = lifecycle::deprecated(), local_path = NULL)
 }
 \arguments{
 \item{chamber}{Which chamber to get data for. Options are:
@@ -32,11 +32,12 @@ Senate data. Thus, the \code{year} for House members is one after that of
 senators in the same Congress.
 }}
 
-\item{les_2}{Whether to use LES 2.0 (instead of Classic Legislative
-Effectiveness Scores).  LES 2.0 credits lawmakers when language
-from their sponsored bills is included in other legislators' bills
-that become law. LES 2.0 is only available for the 117th Congress.
-Classic LES is available for the 93rd through 117th Congresses.}
+\item{les_2}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} This argument is now ignored
+and will be removed in a future release. The 2025 LES dataset now includes
+both LES Classic and LES 2.0 scores in the same dataset. LES 2.0 credits
+lawmakers when language from their sponsored bills is included in other
+legislators' bills that become law. LES 2.0 is only available starting in
+the 117th Congress (2021-present).}
 
 \item{local_path}{(Optional) A file path for reading from a local file.
 If no \code{local_path} is specified, will read data from the Center for
@@ -61,14 +62,8 @@ United States Congress: The lawmakers}. Cambridge University Press.
 \doi{doi:10.1017/CBO9781139032360}
 }
 \examples{
-\dontshow{if (interactive() && !is.null(curl::nslookup("thelawmakers.org", error = FALSE))) withAutoprint(\{ # examplesIf}
-# Classic LES data (93rd-117th Congresses)
-get_les("house", les_2 = FALSE)
-get_les("senate", les_2 = FALSE)
-\dontshow{\}) # examplesIf}
 \dontshow{if (!is.null(curl::nslookup("thelawmakers.org", error = FALSE))) withAutoprint(\{ # examplesIf}
-# LES 2.0 (117th Congress)
-get_les("house", les_2 = TRUE)
-get_les("senate", les_2 = TRUE)
+get_les("house")
+get_les("senate")
 \dontshow{\}) # examplesIf}
 }

--- a/man/get_senate_cloture_votes.Rd
+++ b/man/get_senate_cloture_votes.Rd
@@ -20,7 +20,7 @@ The data is sourced from the official Senate website, specifically
 \url{https://www.senate.gov/legislative/cloture/clotureCounts.htm}.
 }
 \examples{
-\dontshow{if (!is.null(curl::nslookup("www.senate.gov", error = FALSE))) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (!is.null(curl::nslookup("www.senate.gov", error = FALSE))) withAutoprint(\{ # examplesIf}
 get_senate_cloture_votes()
 \dontshow{\}) # examplesIf}
 }

--- a/man/get_senate_sessions.Rd
+++ b/man/get_senate_sessions.Rd
@@ -46,7 +46,7 @@ be dealing with special sessions (denoted \code{"S"}), not just numbered
 sessions.
 }
 \examples{
-\dontshow{if (!is.null(curl::nslookup("www.senate.gov", error = FALSE))) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (!is.null(curl::nslookup("www.senate.gov", error = FALSE))) withAutoprint(\{ # examplesIf}
 get_senate_sessions()
 \dontshow{\}) # examplesIf}
 }

--- a/man/get_voteview_member_votes.Rd
+++ b/man/get_voteview_member_votes.Rd
@@ -47,7 +47,7 @@ and Luke Sonnet (2025).
 \emph{Voteview: Congressional Roll-Call Votes Database}. \url{https://voteview.com/}
 }
 \examples{
-\dontshow{if (interactive() && !is.null(curl::nslookup("voteview.com", error = FALSE))) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (interactive() && !is.null(curl::nslookup("voteview.com", error = FALSE))) withAutoprint(\{ # examplesIf}
 get_voteview_member_votes()
 
 # Get data for only one chamber
@@ -58,7 +58,7 @@ get_voteview_member_votes(chamber = "senate")
 get_voteview_member_votes(congress = 110)
 get_voteview_member_votes(congress = current_congress())
 \dontshow{\}) # examplesIf}
-\dontshow{if (!is.null(curl::nslookup("voteview.com", error = FALSE))) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (!is.null(curl::nslookup("voteview.com", error = FALSE))) withAutoprint(\{ # examplesIf}
 # Get data for a set of Congresses
 get_voteview_member_votes(congress = 1:3)
 \dontshow{\}) # examplesIf}

--- a/man/get_voteview_members.Rd
+++ b/man/get_voteview_members.Rd
@@ -54,7 +54,7 @@ and Luke Sonnet (2025).
 \emph{Voteview: Congressional Roll-Call Votes Database}. \url{https://voteview.com/}
 }
 \examples{
-\dontshow{if (interactive() && !is.null(curl::nslookup("voteview.com", error = FALSE))) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (interactive() && !is.null(curl::nslookup("voteview.com", error = FALSE))) withAutoprint(\{ # examplesIf}
 get_voteview_members()
 
 # Get data for only one chamber
@@ -62,12 +62,12 @@ get_voteview_members()
 get_voteview_members(chamber = "house")
 get_voteview_members(chamber = "senate")
 \dontshow{\}) # examplesIf}
-\dontshow{if (!is.null(curl::nslookup("voteview.com", error = FALSE))) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (!is.null(curl::nslookup("voteview.com", error = FALSE))) withAutoprint(\{ # examplesIf}
 # Get data for a specific Congress
 get_voteview_members(congress = 100)
 get_voteview_members(congress = current_congress())
 \dontshow{\}) # examplesIf}
-\dontshow{if (interactive() && !is.null(curl::nslookup("voteview.com", error = FALSE))) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (interactive() && !is.null(curl::nslookup("voteview.com", error = FALSE))) withAutoprint(\{ # examplesIf}
 # Get data for a set of Congresses
 get_voteview_members(congress = 1:10)
 \dontshow{\}) # examplesIf}

--- a/man/get_voteview_parties.Rd
+++ b/man/get_voteview_parties.Rd
@@ -54,7 +54,7 @@ and Luke Sonnet (2025).
 \emph{Voteview: Congressional Roll-Call Votes Database}. \url{https://voteview.com/}
 }
 \examples{
-\dontshow{if (interactive() && !is.null(curl::nslookup("voteview.com", error = FALSE))) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (interactive() && !is.null(curl::nslookup("voteview.com", error = FALSE))) withAutoprint(\{ # examplesIf}
 get_voteview_parties()
 
 # get parties for only one chamber
@@ -62,12 +62,12 @@ get_voteview_parties()
 get_voteview_parties(chamber = "house")
 get_voteview_parties(chamber = "senate")
 \dontshow{\}) # examplesIf}
-\dontshow{if (!is.null(curl::nslookup("voteview.com", error = FALSE))) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (!is.null(curl::nslookup("voteview.com", error = FALSE))) withAutoprint(\{ # examplesIf}
 # get parties for a specific Congress
 get_voteview_parties(congress = 100)
 get_voteview_parties(congress = current_congress())
 \dontshow{\}) # examplesIf}
-\dontshow{if (interactive() && !is.null(curl::nslookup("voteview.com", error = FALSE))) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (interactive() && !is.null(curl::nslookup("voteview.com", error = FALSE))) withAutoprint(\{ # examplesIf}
 # get parties for a set of Congresses
 get_voteview_parties(congress = 1:10)
 \dontshow{\}) # examplesIf}

--- a/man/get_voteview_rollcall_votes.Rd
+++ b/man/get_voteview_rollcall_votes.Rd
@@ -49,7 +49,7 @@ and Luke Sonnet (2025).
 \emph{Voteview: Congressional Roll-Call Votes Database}. \url{https://voteview.com/}
 }
 \examples{
-\dontshow{if (interactive() && !is.null(curl::nslookup("voteview.com", error = FALSE))) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (interactive() && !is.null(curl::nslookup("voteview.com", error = FALSE))) withAutoprint(\{ # examplesIf}
 get_voteview_rollcall_votes()
 
 # Get data for only one chamber
@@ -57,12 +57,12 @@ get_voteview_rollcall_votes()
 get_voteview_rollcall_votes(chamber = "house")
 get_voteview_rollcall_votes(chamber = "senate")
 \dontshow{\}) # examplesIf}
-\dontshow{if (!is.null(curl::nslookup("voteview.com", error = FALSE))) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (!is.null(curl::nslookup("voteview.com", error = FALSE))) withAutoprint(\{ # examplesIf}
 # Get data for a specific Congress
 get_voteview_rollcall_votes(congress = 100)
 get_voteview_rollcall_votes(congress = current_congress())
 \dontshow{\}) # examplesIf}
-\dontshow{if (interactive() && !is.null(curl::nslookup("voteview.com", error = FALSE))) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (interactive() && !is.null(curl::nslookup("voteview.com", error = FALSE))) withAutoprint(\{ # examplesIf}
 # Get data for a set of Congresses
 get_voteview_rollcall_votes(congress = 1:10)
 \dontshow{\}) # examplesIf}

--- a/man/read_html_table.Rd
+++ b/man/read_html_table.Rd
@@ -23,13 +23,13 @@ A tibble.
 as a dataframe.
 }
 \examples{
-\dontshow{if (!is.null(curl::nslookup("voteview.com", error = FALSE))) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (!is.null(curl::nslookup("voteview.com", error = FALSE))) withAutoprint(\{ # examplesIf}
 # The table used in `get_senate_cloture_votes()`
 # NOTE: `get_senate_cloture_votes()` performs some cleaning on this table
 read_html_table(url = "https://www.senate.gov/legislative/cloture/clotureCounts.htm",
                 css = ".cloturecount")
 \dontshow{\}) # examplesIf}
-\dontshow{if (!is.null(curl::nslookup("www.baseball-reference.com", error = FALSE))) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (!is.null(curl::nslookup("www.baseball-reference.com", error = FALSE))) withAutoprint(\{ # examplesIf}
 # A table from Baseball Reference
 read_html_table(url = "https://www.baseball-reference.com/friv/rules-changes-stats.shtml",
                 css = "#time_of_game")

--- a/tests/testthat/test-build_url.R
+++ b/tests/testthat/test-build_url.R
@@ -140,16 +140,10 @@ test_that("`build_url()` for HVW", {
 # LES --------------------------------------------
 test_that("`build_les_url()`: online paths", {
   # classic LES
-  expect_equal(build_les_url(chamber_code = "H", les_2 = FALSE),
-               "https://thelawmakers.org/wp-content/uploads/2023/04/CELHouse93to117ReducedClassic.dta")
-  expect_equal(build_les_url(chamber_code = "S", les_2 = FALSE),
-               "https://thelawmakers.org/wp-content/uploads/2023/04/CELSenate93to117ReducedClassic.dta")
-
-  # LES 2
-  expect_equal(build_les_url(chamber_code = "H", les_2 = TRUE),
-               "https://thelawmakers.org/wp-content/uploads/2023/04/CELHouse117ReducedLES2.dta")
-  expect_equal(build_les_url(chamber_code = "S", les_2 = TRUE),
-               "https://thelawmakers.org/wp-content/uploads/2023/04/CELSenate117ReducedLES2.dta")
+  expect_equal(build_les_url(chamber_code = "H"),
+               "https://thelawmakers.org/wp-content/uploads/2025/03/CELHouse93to118Reduced.dta")
+  expect_equal(build_les_url(chamber_code = "S"),
+               "https://thelawmakers.org/wp-content/uploads/2025/03/CELSenate93to118Reduced.dta")
 })
 
 test_that("`build_les_url()`: invalid `chamber_code` errors", {
@@ -162,11 +156,11 @@ test_that("`build_les_url()`: invalid `chamber_code` errors", {
 
 test_that("`build_url()` for LES", {
   # basics
-  # NOTE: `sheet_type` in `build_url()` refers to `les_2` for LES data
+  # NOTE: `sheet_type` is not used for LES
   expect_equal(build_url(data_source = "les", chamber = "sen", sheet_type = FALSE),
-               "https://thelawmakers.org/wp-content/uploads/2023/04/CELSenate93to117ReducedClassic.dta")
+               "https://thelawmakers.org/wp-content/uploads/2025/03/CELSenate93to118Reduced.dta")
   expect_equal(build_url(data_source = "les", chamber = "house", sheet_type = TRUE),
-               "https://thelawmakers.org/wp-content/uploads/2023/04/CELHouse117ReducedLES2.dta")
+               "https://thelawmakers.org/wp-content/uploads/2025/03/CELHouse93to118Reduced.dta")
 
   # need to specify a chamber
   expect_error(build_url(data_source = "les"),

--- a/tests/testthat/test-get_hvw_data.R
+++ b/tests/testthat/test-get_hvw_data.R
@@ -159,3 +159,15 @@ test_that("basic dta example", {
   expect_equal(as.character(sort(unique(from_dta$state))),
                state.abb)
 })
+
+test_that("HVW House data includes non-voting members", {
+  skip_if_offline()
+
+  hvw_hr <- get_hvw_data("hr")
+
+  expect_s3_class(hvw_hr$st_name, "factor")
+  expect_length(levels(hvw_hr$st_name), 56)
+  expect_identical(levels(hvw_hr$st_name), c(state.abb,
+                                             "AS", "DC", "GU", "MP", "PR", "VI"))
+  expect_contains(hvw_hr$st_name, c("AS", "DC", "GU", "MP", "PR", "VI"))
+})

--- a/tests/testthat/test-get_les.R
+++ b/tests/testthat/test-get_les.R
@@ -1,91 +1,67 @@
-test_that("LES classic House data", {
+test_that("LES 93rd-118th House data", {
   skip_if_offline()
 
-  hr_classic <- get_les("house", les_2 = FALSE)
+  hr <- get_les("hr")
 
   # data checks
-  expect_s3_class(hr_classic, "tbl_df")
-  expect_length(hr_classic, 60)
-  expect_equal(nrow(hr_classic), 11158)
-  expect_equal(unique(hr_classic$congress), 93:117)
-  expect_equal(unique(hr_classic$year), seq(1973, 2021, 2))
+  expect_s3_class(hr, "tbl_df")
+  expect_length(hr, 88)
+  expect_equal(nrow(hr), 11606)
+  expect_equal(unique(hr$congress), 93:118)
+  # house data uses the first year of the Congress
+  expect_equal(unique(hr$year), seq(1973, 2023, 2))
+  # `st_name` includes non-voting members' territories
+  expect_identical(levels(hr$st_name),
+                   c(datasets::state.abb,
+                     "AS", "DC", "GU", "MP", "PR", "VI"))
 
   # chamber argument
-  expect_equal(hr_classic, get_les("hr", les_2 = FALSE))
+  expect_equal(hr, get_les("house"))
 })
 
-test_that("LES classic Senate data", {
+test_that("LES 93rd-118th Senate data", {
   skip_if_offline()
 
-  s_classic <- get_les("senate", les_2 = FALSE)
+  sen <- get_les("s")
 
   # data checks
-  expect_s3_class(s_classic, "tbl_df")
-  expect_length(s_classic, 60)
-  expect_equal(nrow(s_classic), 2533)
-  expect_equal(unique(s_classic$congress), 93:117)
-  expect_equal(unique(s_classic$year), seq(1972, 2020, 2))
+  expect_s3_class(sen, "tbl_df")
+  expect_length(sen, 88)
+  expect_equal(nrow(sen), 2635)
+  expect_equal(unique(sen$congress), 93:118)
+  # senate data uses the year of the election
+  expect_equal(unique(sen$year), seq(1972, 2022, 2))
+  # `state` just includes states
+  expect_identical(levels(sen$state), datasets::state.abb)
 
   # chamber argument
-  expect_equal(s_classic, get_les("s", les_2 = FALSE))
-})
-
-test_that("LES 2.0 House data", {
-  skip_if_offline()
-
-  hr_2 <- get_les("hr", les_2 = TRUE)
-
-  # data checks
-  expect_s3_class(hr_2, "tbl_df")
-  expect_length(hr_2, 60)
-  expect_equal(nrow(hr_2), 454)
-  expect_equal(unique(hr_2$congress), 117)
-  expect_equal(unique(hr_2$year), 2021)
-
-  # chamber argument
-  expect_equal(hr_2, get_les("h", les_2 = TRUE))
-})
-
-test_that("LES 2.0 Senate data", {
-  skip_if_offline()
-
-  s_2 <- get_les("sen", les_2 = TRUE)
-
-  # data checks
-  expect_s3_class(s_2, "tbl_df")
-  expect_length(s_2, 60)
-  expect_equal(nrow(s_2), 100)
-  expect_equal(unique(s_2$congress), 117)
-  expect_equal(unique(s_2$year), 2020)
-
-  # chamber argument
-  expect_equal(s_2, get_les("s", les_2 = TRUE))
+  expect_equal(sen, get_les("senate"))
 })
 
 test_that("column types", {
   skip_if_offline()
 
-  # Senate, LES Classic
-  s_1 <- get_les("s", les_2 = FALSE)
-  expect_s3_class(s_1, "tbl_df")
-  expect_length(s_1, 60)
-  expect_equal(nrow(s_1), 2533)
-  expect_length(dplyr::select(s_1, dplyr::where(is.integer)), 33)
-  expect_length(dplyr::select(s_1, dplyr::where(is.double)), 9)
-  expect_length(dplyr::select(s_1, dplyr::where(is.factor)), 2)
-  expect_length(dplyr::select(s_1, dplyr::where(is.character)), 4)
-  expect_length(dplyr::select(s_1, dplyr::where(is.logical)), 12)
+  # Senate data
+  sen <- get_les("sen")
+  expect_s3_class(sen, "tbl_df")
+  expect_length(sen, 88)
+  expect_equal(nrow(sen), 2635)
+  expect_length(dplyr::select(sen, dplyr::where(is.integer)), 54)
+  expect_length(dplyr::select(sen, dplyr::where(is.double)), 15)
+  expect_length(dplyr::select(sen, dplyr::where(is.factor)), 3)
+  expect_length(dplyr::select(sen, dplyr::where(is.character)), 4)
+  expect_length(dplyr::select(sen, dplyr::where(is.logical)), 12)
 
-  # House, LES 2
-  hr_2 <- get_les("hr", les_2 = TRUE)
-  expect_s3_class(hr_2, "tbl_df")
-  expect_length(hr_2, 60)
-  expect_equal(nrow(hr_2), 454)
-  expect_length(dplyr::select(hr_2, dplyr::where(is.integer)), 33)
-  expect_length(dplyr::select(hr_2, dplyr::where(is.double)), 9)
-  expect_length(dplyr::select(hr_2, dplyr::where(is.factor)), 2)
-  expect_length(dplyr::select(hr_2, dplyr::where(is.character)), 3)
-  expect_length(dplyr::select(hr_2, dplyr::where(is.logical)), 13)
+  # House data
+  hr <- get_les("h")
+  expect_s3_class(hr, "tbl_df")
+  expect_length(hr, 88)
+  expect_equal(nrow(hr), 11606)
+  expect_length(dplyr::select(hr, dplyr::where(is.integer)), 54)
+  expect_length(dplyr::select(hr, dplyr::where(is.double)), 15)
+  expect_length(dplyr::select(hr, dplyr::where(is.factor)), 3)
+  expect_length(dplyr::select(hr, dplyr::where(is.character)), 3)
+  expect_length(dplyr::select(hr, dplyr::where(is.logical)), 13)
 })
 
 test_that("LES local reading and writing", {
@@ -98,48 +74,42 @@ test_that("LES local reading and writing", {
   tmp_dta <- tempfile(fileext = ".dta")
 
   ## download data from online
-  s1_online <- get_les("s", les_2 = FALSE)
-  expect_s3_class(s1_online, "tbl_df")
-  readr::write_csv(s1_online, tmp_csv)
+  s_online <- get_les("s")
+  expect_s3_class(s_online, "tbl_df")
+  readr::write_csv(s_online, tmp_csv)
+  readr::write_tsv(s_online, tmp_tsv)
 
-  h1_online <- get_les("hr", les_2 = FALSE)
-  expect_s3_class(h1_online, "tbl_df")
-  readr::write_tsv(h1_online, tmp_tab)
-
-  s2_online <- get_les("s", les_2 = TRUE)
-  expect_s3_class(s1_online, "tbl_df")
-  readr::write_tsv(s2_online, tmp_tsv)
-
-  h2_online <- get_les("hr", les_2 = TRUE)
-  expect_s3_class(h1_online, "tbl_df")
-  haven::write_dta(h2_online, tmp_dta)
+  hr_online <- get_les("hr")
+  expect_s3_class(hr_online, "tbl_df")
+  readr::write_tsv(hr_online, tmp_tab)
+  haven::write_dta(hr_online, tmp_dta)
 
   ## check that local data matches
-  s1_local <- get_les("s", les_2 = FALSE, local_path = tmp_csv)
+  s1_local <- get_les("s", local_path = tmp_csv)
   expect_s3_class(s1_local, "tbl_df")
-  expect_equal(s1_local, haven::zap_label(haven::zap_formats(s1_online)))
+  expect_equal(s1_local, haven::zap_label(haven::zap_formats(s_online)))
 
-  h1_local <- get_les("hr", les_2 = FALSE, local_path = tmp_tab)
+  h1_local <- get_les("hr", local_path = tmp_tab)
   expect_s3_class(h1_local, "tbl_df")
-  expect_equal(h1_local, haven::zap_label(haven::zap_formats(h1_online)))
+  expect_equal(h1_local, haven::zap_label(haven::zap_formats(hr_online)))
 
-  s2_local <- get_les("s", les_2 = TRUE, local_path = tmp_tsv)
+  s2_local <- get_les("s", local_path = tmp_tsv)
   expect_s3_class(s2_local, "tbl_df")
-  expect_equal(s2_local, haven::zap_label(haven::zap_formats(s2_online)))
+  expect_equal(s2_local, haven::zap_label(haven::zap_formats(s_online)))
 
-  h2_local <- get_les("hr", les_2 = TRUE, local_path = tmp_dta)
+  h2_local <- get_les("hr", local_path = tmp_dta)
   expect_s3_class(h2_local, "tbl_df")
   # don't need to zap label/formats since we saved data in a DTA file
-  expect_equal(h2_local, h2_online)
+  expect_equal(h2_local, hr_online)
 
   ## test that re-written data matches
   readr::write_csv(h1_local, tmp_csv)
-  h1_rewritten <- get_les("hr", les_2 = FALSE, local_path = tmp_csv)
+  h1_rewritten <- get_les("hr", local_path = tmp_csv)
   expect_s3_class(h1_rewritten, "tbl_df")
   expect_equal(h1_rewritten, h1_local)
 
   haven::write_dta(s2_local, tmp_dta)
-  s2_rewritten <- get_les("s", les_2 = TRUE, local_path = tmp_dta)
+  s2_rewritten <- get_les("s", local_path = tmp_dta)
   expect_s3_class(s2_rewritten, "tbl_df")
   expect_equal(haven::zap_formats(s2_rewritten), s2_local)
 })


### PR DESCRIPTION
Updated `get_les()` to use new LES data through the 118th Congress. Also made fixes to accommodate the new format of the LES datasets:

* Fixes #30.
* Fixes #32.
* `votepct`, `votepct_sq` columns change from integer to double.
* Deprecated the `get_les(les_2)` argument, and removed the `build_les_url(les_2)` argument. It is no longer needed for the new datasets, which contain both LES versions.
* Updated Roxygen to version 7.3.3.