### PR TITLE
New LES House data file, fix accumulated warnings/test failures

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -11,3 +11,4 @@
 ^pkgdown$
 ^vignettes/\.quarto$
 ^vignettes/*_files$
+^\.claude$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -36,7 +36,7 @@ Suggests:
     knitr,
     mirai (>= 2.5.1),
     quarto,
-    testthat (>= 3.0.0)
+    testthat (>= 3.1.5)
 Config/testthat/edition: 3
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -40,5 +40,5 @@ Suggests:
 Config/testthat/edition: 3
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.3
 VignetteBuilder: quarto
+Config/roxygen2/version: 8.0.0

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: filibustr
 Title: Data Utilities for Congressional Research
 Version: 0.5.2.9000
 Authors@R: 
-    person("Max", "Feinleib", email = "mhfeinleib@gmail.com", role = c("aut", "cre", "cph"),
+    person("Max", "Feinleib", , "mhfeinleib@gmail.com", role = c("aut", "cre", "cph"),
            comment = c(ORCID = "0009-0002-9604-3533"))
 Description: Provides easy-to-understand and consistent interfaces for
     accessing data on the U.S. Congress. The functions in 'filibustr'
@@ -37,8 +37,9 @@ Suggests:
     mirai (>= 2.5.1),
     quarto,
     testthat (>= 3.1.5)
+VignetteBuilder: 
+    quarto
+Config/roxygen2/version: 8.0.0
 Config/testthat/edition: 3
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-VignetteBuilder: quarto
-Config/roxygen2/version: 8.0.0

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,9 @@
   the Center for Effective Lawmaking in June 2025 (#53). The revision corrects
   the `cd`, `female`, and `afam` columns for a small number of legislators. The
   Senate data is unchanged.
+* Fixed a parsing failure in `get_voteview_members()` and `get_voteview_parties()`
+  that set `party_code` to `NA` for members and parties in the 115th-117th
+  Congresses. `party_code` is now complete again.
 * Removed an internal use of `dplyr::case_match()`, which is deprecated as of
   dplyr 1.2.0 (#63). This silences a deprecation warning that could appear when
   calling any `get_*()` function.

--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,8 @@
 * Removed an internal use of `dplyr::case_match()`, which is deprecated as of
   dplyr 1.2.0 (#63). This silences a deprecation warning that could appear when
   calling any `get_*()` function.
+* Fixed a warning in Voteview functions caused by reading literal data without
+  `I()`.
 
 # filibustr 0.5.2 (2026-04-06)
 * Fix for CRAN.

--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,7 @@
   calling any `get_*()` function.
 * Fixed a warning in `get_voteview_*()` and `get_hvw_data()` caused by reading
   literal data without `I()`.
+* Dependency bump: Now requires {testthat} >= 3.1.5.
 
 # filibustr 0.5.2 (2026-04-06)
 * Fix for CRAN.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,8 @@
 # filibustr (development version)
+* `get_les("house")` now downloads the revised House LES data file published by
+  the Center for Effective Lawmaking in June 2025 (#53). The revision corrects
+  the `cd`, `female`, and `afam` columns for a small number of legislators. The
+  Senate data is unchanged.
 
 # filibustr 0.5.2 (2026-04-06)
 * Fix for CRAN.

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,9 @@
   the Center for Effective Lawmaking in June 2025 (#53). The revision corrects
   the `cd`, `female`, and `afam` columns for a small number of legislators. The
   Senate data is unchanged.
+* Removed an internal use of `dplyr::case_match()`, which is deprecated as of
+  dplyr 1.2.0 (#63). This silences a deprecation warning that could appear when
+  calling any `get_*()` function.
 
 # filibustr 0.5.2 (2026-04-06)
 * Fix for CRAN.

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,9 @@
 * Fixed a parsing failure in `get_voteview_members()` and `get_voteview_parties()`
   that set `party_code` to `NA` for members and parties in the 115th-117th
   Congresses. `party_code` is now complete again.
+* `get_voteview_member_votes()` no longer emits a parsing warning. Voteview
+  wrote some missing `prob` values as the string `"N/A"` repeated 100 times,
+  which is now recognized as missing. The returned data is unchanged.
 * Removed an internal use of `dplyr::case_match()`, which is deprecated as of
   dplyr 1.2.0 (#63). This silences a deprecation warning that could appear when
   calling any `get_*()` function.

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,9 +6,9 @@
 * Fixed a parsing failure in `get_voteview_members()` and `get_voteview_parties()`
   that set `party_code` to `NA` for members and parties in the 115th-117th
   Congresses. `party_code` is now complete again.
-* `get_voteview_member_votes()` no longer emits a parsing warning. Voteview
-  wrote some missing `prob` values as the string `"N/A"` repeated 100 times,
-  which is now recognized as missing. The returned data is unchanged.
+* Fixed a parsing failure in `get_voteview_member_votes()`. Voteview wrote some
+  missing `prob` values as the string `"N/A"` repeated 100 times, which is now
+  recognized as missing. The returned data is unchanged.
 * Removed an internal use of `dplyr::case_match()`, which is deprecated as of
   dplyr 1.2.0 (#63). This silences a deprecation warning that could appear when
   calling any `get_*()` function.

--- a/NEWS.md
+++ b/NEWS.md
@@ -9,8 +9,8 @@
 * Removed an internal use of `dplyr::case_match()`, which is deprecated as of
   dplyr 1.2.0 (#63). This silences a deprecation warning that could appear when
   calling any `get_*()` function.
-* Fixed a warning in Voteview functions caused by reading literal data without
-  `I()`.
+* Fixed a warning in `get_voteview_*()` and `get_hvw_data()` caused by reading
+  literal data without `I()`.
 
 # filibustr 0.5.2 (2026-04-06)
 * Fix for CRAN.

--- a/R/build_url.R
+++ b/R/build_url.R
@@ -70,11 +70,13 @@ build_les_url <- function(chamber_code) {
 }
 
 match_chamber <- function(chamber) {
-  chamber_code <- dplyr::case_match(tolower(chamber),
-                                    c("all", "congress", "hs") ~ "HS",
-                                    c("house", "h", "hr") ~ "H",
-                                    c("senate", "s", "sen") ~ "S",
-                                    .default = "HS_default")
+  # `switch()` avoids requiring dplyr (>= 1.2.0) for `recode_values()`.
+  # It is not vectorized, but `chamber` must be length 1 anyway.
+  chamber_code <- switch(tolower(chamber),
+                         all = , congress = , hs = "HS",
+                         house = , h = , hr = "H",
+                         senate = , s = , sen = "S",
+                         "HS_default")
 
   # Warn for invalid chamber argument
   if (chamber_code == "HS_default") {

--- a/R/build_url.R
+++ b/R/build_url.R
@@ -58,10 +58,15 @@ build_les_url <- function(chamber_code) {
     call = rlang::caller_env(2))
   }
 
-  source <- "https://thelawmakers.org/wp-content/uploads/2025/03/CEL"
-  chamber_name <- if (chamber_code == "H") "House" else "Senate"
-
-  paste0(source, chamber_name, "93to118Reduced.dta")
+  # the House and Senate files no longer share a URL pattern:
+  # the House data was revised in June 2025, the Senate data was not
+  if (chamber_code == "H") {
+    paste0("https://thelawmakers.org/wp-content/uploads/2025/06/",
+           "CELHouse93to118Reduced-REVISED-06.26.2025.dta")
+  } else {
+    paste0("https://thelawmakers.org/wp-content/uploads/2025/03/",
+           "CELSenate93to118Reduced.dta")
+  }
 }
 
 match_chamber <- function(chamber) {

--- a/R/get_hvw_data.R
+++ b/R/get_hvw_data.R
@@ -48,7 +48,7 @@ get_hvw_data <- function(chamber, local_path = NULL) {
     # online reading
     url <- build_url(data_source = "hvw", chamber = chamber)
     online_file <- get_online_data(url = url, source_name = "Harvard Dataverse")
-    df <- readr::read_tsv(file = online_file, show_col_types = FALSE)
+    df <- readr::read_tsv(I(online_file), show_col_types = FALSE)
   } else {
     # local reading
     df <- read_local_file(path = local_path, show_col_types = FALSE)

--- a/R/get_voteview_member_votes.R
+++ b/R/get_voteview_member_votes.R
@@ -45,7 +45,7 @@ get_voteview_member_votes <- function(chamber = "all", congress = NULL, local_pa
     url <- build_url(data_source = "voteview", chamber = chamber, congress = congress,
                      sheet_type = "votes")
     online_file <- get_online_data(url = url, source_name = "Voteview")
-    df <- readr::read_csv(online_file, col_types = "ifiddd", na = c("", "NA", "N/A"))
+    df <- readr::read_csv(I(online_file), col_types = "ifiddd", na = c("", "NA", "N/A"))
   } else {
     # local reading
     df <- read_local_file(path = local_path, col_types = "ifiddd", na = c("", "NA", "N/A"))

--- a/R/get_voteview_member_votes.R
+++ b/R/get_voteview_member_votes.R
@@ -40,15 +40,20 @@ get_voteview_member_votes <- function(chamber = "all", congress = NULL, local_pa
     )
   }
 
+  # NOTE: Voteview writes a small number of missing `prob` values as the string
+  # "N/A" repeated 100 times. `na` matches whole fields only, so the repeated
+  # string has to be listed alongside the plain one.
+  na_strings <- c("", "NA", "N/A", strrep("N/A", 100))
+
   if (is.null(local_path)) {
     # online reading
     url <- build_url(data_source = "voteview", chamber = chamber, congress = congress,
                      sheet_type = "votes")
     online_file <- get_online_data(url = url, source_name = "Voteview")
-    df <- readr::read_csv(I(online_file), col_types = "ifiddd", na = c("", "NA", "N/A"))
+    df <- readr::read_csv(I(online_file), col_types = "ifiddd", na = na_strings)
   } else {
     # local reading
-    df <- read_local_file(path = local_path, col_types = "ifiddd", na = c("", "NA", "N/A"))
+    df <- read_local_file(path = local_path, col_types = "ifiddd", na = na_strings)
   }
 
   if (!is.null(local_path)) {

--- a/R/get_voteview_members.R
+++ b/R/get_voteview_members.R
@@ -81,6 +81,9 @@ get_voteview_members <- function(chamber = "all", congress = NULL, local_path = 
     )
   }
 
+  # NOTE: `party_code` is read as a double because Voteview writes some values
+  # in decimal form (e.g., "200.0"), which the integer parser rejects (returning
+  # `NA` with a warning). It is converted back to an integer below.
   if (is.null(local_path)) {
     # online reading
     url <- build_url(data_source = "voteview", chamber = chamber, congress = congress,
@@ -89,7 +92,7 @@ get_voteview_members <- function(chamber = "all", congress = NULL, local_path = 
     df <- readr::read_csv(online_file, col_types = "ifiinfiiiccnnnnnniilnn")
   } else {
     # local reading
-    df <- read_local_file(path = local_path, col_types = "ifiinfiiiccnnnnnniilnn")
+    df <- read_local_file(path = local_path, col_types = "ifiinfdiiccnnnnnniilnn")
   }
 
   if (isTRUE(tools::file_ext(local_path) == "dta")) {
@@ -116,7 +119,7 @@ get_voteview_members <- function(chamber = "all", congress = NULL, local_path = 
   }
 
   df <- df |>
-    dplyr::mutate(dplyr::across(.cols = c("district_code", "born", "died"),
+    dplyr::mutate(dplyr::across(.cols = c("party_code", "district_code", "born", "died"),
                                 .fns = as.integer))
 
   df

--- a/R/get_voteview_members.R
+++ b/R/get_voteview_members.R
@@ -89,7 +89,7 @@ get_voteview_members <- function(chamber = "all", congress = NULL, local_path = 
     url <- build_url(data_source = "voteview", chamber = chamber, congress = congress,
                      sheet_type = "members")
     online_file <- get_online_data(url = url, source_name = "Voteview")
-    df <- readr::read_csv(online_file, col_types = "ifiinfiiiccnnnnnniilnn")
+    df <- readr::read_csv(I(online_file), col_types = "ifiinfdiiccnnnnnniilnn")
   } else {
     # local reading
     df <- read_local_file(path = local_path, col_types = "ifiinfdiiccnnnnnniilnn")

--- a/R/get_voteview_parties.R
+++ b/R/get_voteview_parties.R
@@ -41,6 +41,9 @@ get_voteview_parties <- function(chamber = "all", congress = NULL, local_path = 
     )
   }
 
+  # NOTE: `party_code` is read as a double because Voteview writes some values
+  # in decimal form (e.g., "200.0"), which the integer parser rejects (returning
+  # `NA` with a warning). It is converted back to an integer below.
   if (is.null(local_path)) {
     # online reading
     url <- build_url(data_source = "voteview", chamber = chamber, congress = congress,
@@ -49,7 +52,7 @@ get_voteview_parties <- function(chamber = "all", congress = NULL, local_path = 
     df <- readr::read_csv(online_file, col_types = "ififidddd")
   } else {
     # local reading
-    df <- read_local_file(path = local_path, col_types = "ififidddd")
+    df <- read_local_file(path = local_path, col_types = "ifdfidddd")
   }
 
   # local file fixes
@@ -59,7 +62,7 @@ get_voteview_parties <- function(chamber = "all", congress = NULL, local_path = 
       # no need to specify levels if data is already coming from saved DTA file
       dplyr::mutate(dplyr::across(.cols = c("chamber", "party_name"),
                                   .fns = haven::as_factor),
-                    dplyr::across(.cols = c("congress", "party_code", "n_members"),
+                    dplyr::across(.cols = c("congress", "n_members"),
                                   .fns = as.integer))
   }
 
@@ -69,6 +72,9 @@ get_voteview_parties <- function(chamber = "all", congress = NULL, local_path = 
       filter_congress(congress = congress) |>
       filter_chamber(chamber = chamber)
   }
+
+  df <- df |>
+    dplyr::mutate(dplyr::across(.cols = "party_code", .fns = as.integer))
 
   df
 }

--- a/R/get_voteview_parties.R
+++ b/R/get_voteview_parties.R
@@ -49,7 +49,7 @@ get_voteview_parties <- function(chamber = "all", congress = NULL, local_path = 
     url <- build_url(data_source = "voteview", chamber = chamber, congress = congress,
                      sheet_type = "parties")
     online_file <- get_online_data(url = url, source_name = "Voteview")
-    df <- readr::read_csv(online_file, col_types = "ififidddd")
+    df <- readr::read_csv(I(online_file), col_types = "ifdfidddd")
   } else {
     # local reading
     df <- read_local_file(path = local_path, col_types = "ifdfidddd")

--- a/R/get_voteview_rollcall_votes.R
+++ b/R/get_voteview_rollcall_votes.R
@@ -48,7 +48,7 @@ get_voteview_rollcall_votes <- function(chamber = "all", congress = NULL, local_
     url <- build_url(data_source = "voteview", chamber = chamber, congress = congress,
                      sheet_type = "rollcalls")
     online_file <- get_online_data(url = url, source_name = "Voteview")
-    df <- readr::read_csv(online_file, col_types = "ifiDddiidddddccccc")
+    df <- readr::read_csv(I(online_file), col_types = "ifiDddiidddddccccc")
   } else {
     # local reading
     df <- read_local_file(path = local_path, col_types = "ifiDddiidddddccccc")

--- a/man/filibustr-package.Rd
+++ b/man/filibustr-package.Rd
@@ -20,5 +20,10 @@ Useful links:
 \author{
 \strong{Maintainer}: Max Feinleib \email{mhfeinleib@gmail.com} (\href{https://orcid.org/0009-0002-9604-3533}{ORCID}) [copyright holder]
 
+Authors:
+\itemize{
+  \item Max Feinleib \email{mhfeinleib@gmail.com} (\href{https://orcid.org/0009-0002-9604-3533}{ORCID}) [copyright holder]
+}
+
 }
 \keyword{internal}

--- a/tests/testthat/test-build_url.R
+++ b/tests/testthat/test-build_url.R
@@ -140,8 +140,10 @@ test_that("`build_url()` for HVW", {
 # LES --------------------------------------------
 test_that("`build_les_url()`: online paths", {
   # classic LES
+  # NOTE: the House data was revised in June 2025, the Senate data was not
   expect_equal(build_les_url(chamber_code = "H"),
-               "https://thelawmakers.org/wp-content/uploads/2025/03/CELHouse93to118Reduced.dta")
+               paste0("https://thelawmakers.org/wp-content/uploads/2025/06/",
+                      "CELHouse93to118Reduced-REVISED-06.26.2025.dta"))
   expect_equal(build_les_url(chamber_code = "S"),
                "https://thelawmakers.org/wp-content/uploads/2025/03/CELSenate93to118Reduced.dta")
 })
@@ -160,7 +162,8 @@ test_that("`build_url()` for LES", {
   expect_equal(build_url(data_source = "les", chamber = "sen", sheet_type = FALSE),
                "https://thelawmakers.org/wp-content/uploads/2025/03/CELSenate93to118Reduced.dta")
   expect_equal(build_url(data_source = "les", chamber = "house", sheet_type = TRUE),
-               "https://thelawmakers.org/wp-content/uploads/2025/03/CELHouse93to118Reduced.dta")
+               paste0("https://thelawmakers.org/wp-content/uploads/2025/06/",
+                      "CELHouse93to118Reduced-REVISED-06.26.2025.dta"))
 
   # need to specify a chamber
   expect_error(build_url(data_source = "les"),

--- a/tests/testthat/test-get_hvw_data.R
+++ b/tests/testthat/test-get_hvw_data.R
@@ -1,7 +1,9 @@
 test_that("HVW house data", {
   skip_if_offline()
 
-  house_data <- get_hvw_data("house")
+  # expect no warnings when downloading
+  # (`expect_no_warning()` would ignore deprecation warnings)
+  expect_no_condition(house_data <- get_hvw_data("house"), class = "warning")
 
   # data checks
   expect_s3_class(house_data, "tbl_df")
@@ -18,7 +20,8 @@ test_that("HVW house data", {
 test_that("HVW senate data", {
   skip_if_offline()
 
-  senate_data <- get_hvw_data("senate")
+  # expect no warnings when downloading
+  expect_no_condition(senate_data <- get_hvw_data("senate"), class = "warning")
 
   # data checks
   expect_s3_class(senate_data, "tbl_df")

--- a/tests/testthat/test-get_voteview_member_votes.R
+++ b/tests/testthat/test-get_voteview_member_votes.R
@@ -72,7 +72,7 @@ test_that("filter votes by congress", {
   expect_length(s_votes_117, 6)
   expect_equal(levels(s_votes_117$chamber), "Senate")
   expect_equal(unique(s_votes_117$congress), 117)
-  expect_equal(nrow(s_votes_117), 95152)
+  expect_equal(nrow(s_votes_117), 95238)
 })
 
 test_that("column types", {

--- a/tests/testthat/test-get_voteview_member_votes.R
+++ b/tests/testthat/test-get_voteview_member_votes.R
@@ -29,7 +29,9 @@ test_that("download from Voteview", {
 test_that("filter votes by chamber", {
   skip_if_offline()
 
-  s_votes <- get_voteview_member_votes(chamber = "s")
+  # expect no warnings when downloading
+  # (`expect_no_warning()` would ignore deprecation warnings)
+  expect_no_condition(s_votes <- get_voteview_member_votes(chamber = "s"), class = "warning")
   expect_s3_class(s_votes, "tbl_df")
   expect_length(s_votes, 6)
   expect_equal(levels(s_votes$chamber), "Senate")
@@ -68,7 +70,9 @@ test_that("filter votes by chamber", {
 test_that("filter votes by congress", {
   skip_if_offline()
 
-  votes_1_5 <- get_voteview_member_votes(congress = 1:5)
+  # expect no warnings when downloading
+  # (the 1st-5th Congresses contain repeated "N/A" `prob` values)
+  expect_no_condition(votes_1_5 <- get_voteview_member_votes(congress = 1:5), class = "warning")
   expect_s3_class(votes_1_5, "tbl_df")
   expect_length(votes_1_5, 6)
   expect_equal(levels(votes_1_5$chamber), c("House", "Senate"))

--- a/tests/testthat/test-get_voteview_member_votes.R
+++ b/tests/testthat/test-get_voteview_member_votes.R
@@ -40,6 +40,14 @@ test_that("filter votes by chamber", {
     expect_equal(unique(s_votes$congress), 1:current_congress())
   }
 
+  # `NA` vote probabilities are limited
+  expect_lt(mean(is.na(s_votes$prob)), 0.12)
+  expect_lt(s_votes |>
+              dplyr::summarize(pct_na = mean(is.na(prob)), .by = c(congress, chamber)) |>
+              dplyr::pull(pct_na) |>
+              max(),
+            0.35)
+
   skip("Skipping slow online member-votes downloads.")
 
   hr_votes <- get_voteview_member_votes(chamber = "hr")

--- a/tests/testthat/test-get_voteview_member_votes.R
+++ b/tests/testthat/test-get_voteview_member_votes.R
@@ -16,6 +16,14 @@ test_that("download from Voteview", {
   }
   expect_gte(min(online_votes$prob, na.rm = TRUE), 0)
   expect_lte(max(online_votes$prob, na.rm = TRUE), 100)
+
+  # `NA` vote probabilities are limited
+  expect_lt(mean(is.na(online_votes$prob)), 0.16)
+  expect_lt(online_votes |>
+              dplyr::summarize(pct_na = mean(is.na(prob)), .by = c(congress, chamber)) |>
+              dplyr::pull(pct_na) |>
+              max(),
+            0.50)
 })
 
 test_that("filter votes by chamber", {

--- a/tests/testthat/test-get_voteview_members.R
+++ b/tests/testthat/test-get_voteview_members.R
@@ -102,6 +102,21 @@ test_that("column types", {
   expect_length(dplyr::select(members_98, dplyr::where(is.logical)), 1)
 })
 
+test_that("party codes are complete", {
+  skip_if_offline()
+  # check that party codes in 115th-117th Congresses are correctly read as integers
+
+  # Congress-level files
+  members_115_117 <- get_voteview_members(congress = 115:117)
+  expect_type(members_115_117$party_code, "integer")
+  expect_false(anyNA(members_115_117$party_code))
+
+  # all-Congresses file
+  all_members <- get_voteview_members()
+  expect_type(all_members$party_code, "integer")
+  expect_false(anyNA(all_members$party_code))
+})
+
 test_that("local read/write", {
   skip_if_offline()
 

--- a/tests/testthat/test-get_voteview_members.R
+++ b/tests/testthat/test-get_voteview_members.R
@@ -1,7 +1,9 @@
 test_that("download from Voteview", {
   skip_if_offline()
 
-  online_voteview_members <- get_voteview_members()
+  # expect no warnings when downloading
+  # (`expect_no_warning()` would ignore deprecation warnings)
+  expect_no_condition(online_voteview_members <- get_voteview_members(), class = "warning")
   expect_s3_class(online_voteview_members, "tbl_df")
   expect_length(online_voteview_members, 22)
   # floor on all-time members length

--- a/tests/testthat/test-get_voteview_members.R
+++ b/tests/testthat/test-get_voteview_members.R
@@ -45,9 +45,11 @@ test_that("filter by chamber", {
 
   expect_gt(nrow(hr), nrow(s))
 
-  # TODO: how to correctly test for a warning? This still produces a warning in the test.
-  # expect_warning(get_voteview_members(chamber = "not a chamber"),
-  #                "Invalid `chamber` argument \\(\"not a chamber\"\\) provided\\. Using `chamber = \"all\"`\\.")
+  # Ensure line width doesn't cause the below test to fail
+  local_reproducible_output(width = 120)
+  expect_warning(get_voteview_members(chamber = "not a chamber"),
+                 'Invalid `chamber` argument ("not a chamber") provided. Using `chamber = "all"`',
+                 fixed = TRUE)
 })
 
 test_that("filter by congress", {

--- a/tests/testthat/test-get_voteview_parties.R
+++ b/tests/testthat/test-get_voteview_parties.R
@@ -95,7 +95,7 @@ test_that("local read filtering", {
   all_parties <- get_voteview_parties()
   expect_s3_class(all_parties, "tbl_df")
   expect_length(all_parties, 9)
-  expect_equal(nrow(all_parties), 845)
+  expect_equal(nrow(all_parties), 848)
   haven::write_dta(all_parties, tmp_dta)
   readr::write_csv(all_parties, tmp_csv)
 
@@ -112,7 +112,7 @@ test_that("local read filtering", {
   hr_parties <- get_voteview_parties(chamber = "hr",
                                      local_path = tmp_dta)
   expect_s3_class(hr_parties, "tbl_df")
-  expect_equal(nrow(hr_parties), 521)
+  expect_equal(nrow(hr_parties), 524)
   expect_equal(haven::zap_formats(hr_parties),
                dplyr::filter(all_parties, chamber != "Senate") |>
                  dplyr::mutate(chamber = droplevels(chamber)))

--- a/tests/testthat/test-get_voteview_parties.R
+++ b/tests/testthat/test-get_voteview_parties.R
@@ -49,6 +49,21 @@ test_that("parties column types", {
   expect_length(dplyr::select(parties_25, dplyr::where(is.factor)), 2)
 })
 
+test_that("party codes are complete", {
+  skip_if_offline()
+  # check that party codes in 115th-117th Congresses are correctly read as integers
+
+  # Congress-level files
+  parties_115_117 <- get_voteview_parties(congress = 115:117)
+  expect_type(parties_115_117$party_code, "integer")
+  expect_false(anyNA(parties_115_117$party_code))
+
+  # all-Congresses file
+  all_parties <- get_voteview_parties()
+  expect_type(all_parties$party_code, "integer")
+  expect_false(anyNA(all_parties$party_code))
+})
+
 test_that("local read/write", {
   skip_if_offline()
 

--- a/tests/testthat/test-get_voteview_parties.R
+++ b/tests/testthat/test-get_voteview_parties.R
@@ -1,7 +1,9 @@
 test_that("all parties data", {
   skip_if_offline()
 
-  all_parties <- get_voteview_parties()
+  # expect no warnings when downloading
+  # (`expect_no_warning()` would ignore deprecation warnings)
+  expect_no_condition(all_parties <- get_voteview_parties(), class = "warning")
   expect_s3_class(all_parties, "tbl_df")
   expect_length(all_parties, 9)
   expect_equal(levels(all_parties$chamber),

--- a/tests/testthat/test-get_voteview_parties.R
+++ b/tests/testthat/test-get_voteview_parties.R
@@ -79,7 +79,7 @@ test_that("local read/write", {
   expect_s3_class(all_parties_online, "tbl_df")
   expect_length(all_parties_online, 9)
   # this table will grow in each congress
-  expect_gte(nrow(all_parties_online), 845)
+  expect_gte(nrow(all_parties_online), 848)
   expect_equal(levels(all_parties_online$chamber), c("President", "House", "Senate"))
   readr::write_tsv(all_parties_online, tmp_tsv)
 
@@ -112,7 +112,8 @@ test_that("local read filtering", {
   all_parties <- get_voteview_parties()
   expect_s3_class(all_parties, "tbl_df")
   expect_length(all_parties, 9)
-  expect_equal(nrow(all_parties), 848)
+  # this table will grow in each congress
+  expect_gte(nrow(all_parties), 848)
   haven::write_dta(all_parties, tmp_dta)
   readr::write_csv(all_parties, tmp_csv)
 
@@ -129,7 +130,8 @@ test_that("local read filtering", {
   hr_parties <- get_voteview_parties(chamber = "hr",
                                      local_path = tmp_dta)
   expect_s3_class(hr_parties, "tbl_df")
-  expect_equal(nrow(hr_parties), 524)
+  # this table will grow in each congress
+  expect_gte(nrow(hr_parties), 524)
   expect_equal(haven::zap_formats(hr_parties),
                dplyr::filter(all_parties, chamber != "Senate") |>
                  dplyr::mutate(chamber = droplevels(chamber)))

--- a/tests/testthat/test-get_voteview_rollcall_votes.R
+++ b/tests/testthat/test-get_voteview_rollcall_votes.R
@@ -1,7 +1,9 @@
 test_that("download from Voteview", {
   skip_if_offline()
 
-  online_rollcalls <- get_voteview_rollcall_votes()
+  # expect no warnings when downloading
+  # (`expect_no_warning()` would ignore deprecation warnings)
+  expect_no_condition(online_rollcalls <- get_voteview_rollcall_votes(), class = "warning")
   expect_s3_class(online_rollcalls, "tbl_df")
   expect_length(online_rollcalls, 18)
   expect_equal(levels(online_rollcalls$chamber), c("House", "Senate"))

--- a/tests/testthat/test-utils_data_reading.R
+++ b/tests/testthat/test-utils_data_reading.R
@@ -5,7 +5,7 @@ test_that("get_online_data(): Voteview members", {
     "https://voteview.com/static/data/out/members/S117_members.csv", "Voteview")
   expect_type(vv_resp_members_s117, "character")
   # check that CSV format works
-  members_s117_df <- readr::read_csv(vv_resp_members_s117, show_col_types = FALSE)
+  members_s117_df <- readr::read_csv(I(vv_resp_members_s117), show_col_types = FALSE)
   expect_s3_class(members_s117_df, "tbl_df")
   expect_length(members_s117_df, 22)
   expect_equal(nrow(members_s117_df), 104)
@@ -20,7 +20,7 @@ test_that("get_online_data(): Voteview parties", {
     "https://voteview.com/static/data/out/parties/HSall_parties.csv", "Voteview")
   expect_type(vv_resp_parties, "character")
   # check that CSV format works
-  parties_df <- readr::read_csv(vv_resp_parties, show_col_types = FALSE)
+  parties_df <- readr::read_csv(I(vv_resp_parties), show_col_types = FALSE)
   expect_s3_class(parties_df, "tbl_df")
   expect_length(parties_df, 9)
   expect_equal(unique(parties_df$chamber), c("President", "House", "Senate"))


### PR DESCRIPTION
Fixes #53, fixes #63.

* Use updated LES House data file (#53).
* Remove deprecated `dplyr::case_match()` (#63). Using `switch()` instead of `dplyr::recode_values()`, which would force a hard version minimum of dplyr 1.2.0.
* Fixed parsing failures:
  * Decimal instead of integer `party_code` values.
  * Member-vote `prob` probabilities listed as "N/AN/AN/A..." (100 times).
* Use `I()` when reading literal CSV/TSV data (fixes a warning).

Internal:
* Update tests for data sets that now have more rows.
* Use Roxygen 8.0.0.
* Ignore any Claude files in package build.